### PR TITLE
Placeholder release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# VS Code Kubernetes Tools API
+# API Library for Visual Studio Code Kubernetes Tools
+
+A NPM package providing documentation and helpers for using the [Kubernetes extension for Visual
+Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools)
+in your own VS Code extensions.
+
+This is a placeholder release of the package for internal development purposes; the API surfaced
+in this package is not yet in the released build of the extension.  Full package
+documentation will be added when the extension API is released.
 
 # Contributing
 


### PR DESCRIPTION
We want to test our process for releasing to NPM before it becomes time-critical.  This PR creates a placeholder release which should be a working NPM package but makes it clear that it is for internal dev/testing purposes only and that the API is not available yet.