### PR TITLE
Fixed omitting InactiveCluster explorer node type

### DIFF
--- a/ts/cluster-explorer/v1.ts
+++ b/ts/cluster-explorer/v1.ts
@@ -273,6 +273,7 @@ export namespace ClusterExplorerV1 {
         ClusterExplorerGroupingFolderNode |
         ClusterExplorerResourceFolderNode |
         ClusterExplorerContextNode |
+        ClusterExplorerInactiveContextNode |
         ClusterExplorerConfigDataItemNode |
         ClusterExplorerErrorNode |
         ClusterExplorerHelmReleaseNode |


### PR DESCRIPTION
Fixup for a last-minute change in #6 where a new node type got added but wasn't added to the ClusterExplorerNode union type.