### PR TITLE
Handle the returned API object predating APIBroker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-kubernetes-tools-api",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Documents and encapsulates the API for the Kubernetes extension for Visual Studio Code",
   "main": "js/index.js",
   "types": "js/index.d.ts",

--- a/ts/helper.ts
+++ b/ts/helper.ts
@@ -23,6 +23,9 @@ export class ExtensionHelper implements Extension {
         if (!apiBroker) {
             return { available: false, reason: "extension-not-available" };
         }
+        if (!apiBroker.get) {
+            return { available: false, reason: "version-unknown" };
+        }
         return apiBroker.get(component, version);
     }
     async get<T>(component: ComponentKey<T>, version: Version<T>): Promise<API<T>> {


### PR DESCRIPTION
Users may have an old version of the k8s extension pinned - or, during the pre-launch phase, they may have the marketplace version that doesn't have the APIBroker.  We should return an 'extension too old' error in this case rather than failing with a mysterious 'apiBroker.get is not defined' exception.