### PR TITLE
Add new Local Redirection Debugger API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-kubernetes-tools-api",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/ts/helper.ts
+++ b/ts/helper.ts
@@ -8,6 +8,7 @@ import { HelmV1 } from './helm/v1';
 import { CloudExplorerV1 } from './cloudexplorer/v1';
 import { ConfigurationV1 } from './configuration/v1';
 import { ClusterExplorerV1_1 } from './cluster-explorer/v1_1';
+import { LocalRedirectionDebuggerV1 } from './localredirectiondebugger/v1';
 
 class Lazy<T> {
     private value: T | undefined = undefined;
@@ -54,6 +55,9 @@ export class ExtensionHelper implements Extension {
     });
     readonly configuration = readonlify({
         v1: this.get<ConfigurationV1>("configuration", "v1"),
+    });
+    readonly localRedirectionDebugger = readonlify({
+        v1: this.get<LocalRedirectionDebuggerV1>("localredirectiondebugger", "v1"),
     });
 }
 

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -12,6 +12,8 @@ import { CloudExplorerAPI } from './cloudexplorer/versions';
 import { CloudExplorerV1 } from './cloudexplorer/v1';
 import { ConfigurationAPI } from './configuration/versions';
 import { ConfigurationV1 } from './configuration/v1';
+import { LocalRedirectionDebuggerAPI } from './localredirectiondebugger/versions';
+import { LocalRedirectionDebuggerV1 } from './localredirectiondebugger/v1';
 
 export { ClusterProviderAPI } from './clusterprovider/versions';
 export { ClusterProviderV1 } from './clusterprovider/v1';
@@ -31,6 +33,8 @@ export { CloudExplorerV1 } from './cloudexplorer/v1';
 
 export { ConfigurationAPI } from './configuration/versions';
 export { ConfigurationV1 } from './configuration/v1';
+export { LocalRedirectionDebuggerAPI } from './localredirectiondebugger/versions';
+export { LocalRedirectionDebuggerV1 } from './localredirectiondebugger/v1';
 
 /**
  * Provides convenient access to the Kubernetes extension's API.
@@ -92,6 +96,10 @@ export interface Extension {
      * Provides access to the Kubernetes extension's Configuration API.
      */
     readonly configuration: ConfigurationAPI;
+    /**
+     * Provides access to the Kubernetes extension's Local Redirection Debugger API.
+     */
+    readonly localRedirectionDebugger: LocalRedirectionDebuggerAPI;
 }
 
 /**
@@ -167,6 +175,7 @@ export type ComponentKey<T> =
     T extends HelmV1 ? "helm" :
     T extends CloudExplorerV1 ? "cloudexplorer" :
     T extends ConfigurationV1 ? "configuration" :
+    T extends LocalRedirectionDebuggerV1 ? "localredirectiondebugger" :
     "invalid_api_interface";
 
 /**
@@ -180,4 +189,5 @@ export type Version<T> =
     T extends HelmV1 ? "v1" :
     T extends CloudExplorerV1 ? "v1" :
     T extends ConfigurationV1 ? "v1" :
+    T extends LocalRedirectionDebuggerV1 ? "v1" :
     "invalid_api_interface";

--- a/ts/localredirectiondebugger/v1.ts
+++ b/ts/localredirectiondebugger/v1.ts
@@ -10,11 +10,6 @@ export interface LocalRedirectionDebuggerV1 {
      * @param localRedirectionDebugger The local redirection debugger to be registered.
      */
     register(localRedirectionDebugger: LocalRedirectionDebuggerV1.LocalRedirectionDebugger): void;
-    /**
-     * Lists registered local redirection debuggers.
-     * @returns The local redirection debuggers registered for the Debug (Redirect locally) command.
-     */
-    list(): ReadonlyArray<LocalRedirectionDebuggerV1.LocalRedirectionDebugger>;
 }
 
 export namespace LocalRedirectionDebuggerV1 {

--- a/ts/localredirectiondebugger/v1.ts
+++ b/ts/localredirectiondebugger/v1.ts
@@ -1,0 +1,42 @@
+/**
+ * Supports working with the Debug (Redirect locally) command.
+ */
+export interface LocalRedirectionDebuggerV1 {
+    /**
+     * Registers a local redirection debugger. The debugger will be invoked on user action
+     * when the user selects the Debug (Redirect locally) command in the cluster explorer,
+     * or when running the Debug (Redirect locally) command in the command palette. The
+     * local redirection debugger wil show its own user interface once invoked.
+     * @param localRedirectionDebugger The local redirection debugger to be registered.
+     */
+    register(localRedirectionDebugger: LocalRedirectionDebuggerV1.LocalRedirectionDebugger): void;
+    /**
+     * Lists registered local redirection debuggers.
+     * @returns The local redirection debuggers registered for the Debug (Redirect locally) command.
+     */
+    list(): ReadonlyArray<LocalRedirectionDebuggerV1.LocalRedirectionDebugger>;
+}
+
+export namespace LocalRedirectionDebuggerV1 {
+    /**
+     * Represents a local redirection debugger - an object that provides a
+     * user interface for working with a type of debugger redirecting the
+     * traffic from the user's cluster to the local machine.
+     */
+    export interface LocalRedirectionDebugger {
+        /**
+         * A programmatic identifier for the local redirection debugger.
+         */
+        readonly id: string;
+        /**
+         * Invoked by the Kubernetes extension on user action to start
+         * the debugger on the targeted node.
+         * @param target The object passed by Visual Studio Code as the
+         * command target. Use the cluster explorer API to resolve this
+         * target (resolveCommandTarget method). This parameter will be
+         * undefined if the debugging action is initiated through the
+         * Visual Studio command palette.
+         */
+        startDebugging(target?: any): void;
+    }
+}

--- a/ts/localredirectiondebugger/versions.ts
+++ b/ts/localredirectiondebugger/versions.ts
@@ -1,0 +1,13 @@
+import { API } from '..';
+
+import { LocalRedirectionDebuggerV1 } from './v1';
+
+/**
+ * Provides access to the Kubernetes extension's Local Redirection Debugger API.
+ */
+export interface LocalRedirectionDebuggerAPI {
+    /**
+     * Provides access to v1 of the Kubernetes extension's Local Redirection Debugger API.
+     */
+    readonly v1: Promise<API<LocalRedirectionDebuggerV1>>;
+}


### PR DESCRIPTION
Please note that this PR won't be merged until the corresponding logic in vscode-kubernetes-tools is implemented.

This new API will allow other extensions to register as Local Redirection Debuggers. Such extension will provide a user interface for working with a type of debugger redirecting the traffic from the user's cluster to the local machine, rather than doing it remotely.